### PR TITLE
Improve formatting of cat command

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func catGist(id string, files []string) error {
 			}
 		}
 
-		fmt.Print(*gf.Content)
+		fmt.Printf("---\n# File: %s\n---\n\n%s\n\n", string(filename), *gf.Content)
 	}
 
 	return nil


### PR DESCRIPTION
Currently it's not clear where one file ends and where another begins.
My purpose is to have delimiter like this:

```

---
# File: file_name_1.txt

---

Content 1 

---
# File: file_name_2.txt

---

Content 2

```
